### PR TITLE
Updated homepage links, added Discord channel link to announcement.

### DIFF
--- a/webapp/src/features/event/EventAnnouncements.tsx
+++ b/webapp/src/features/event/EventAnnouncements.tsx
@@ -10,6 +10,17 @@ const EventAnnouncements = () => {
     const discordMessage = getDiscordMessage(eventScratchpad);
     const twitterMessage = getTwitterMessage(eventScratchpad);
 
+    const discordFooterInstructions = <>
+        <p className="mb-0 mt-2">Paste your announcement text to <a target="_blank" 
+                rel="noopener noreferrer" 
+                href="https://discord.com/channels/1004489038159413248/1004489042890588165">
+                    #s4-vrchat-events
+            </a> in Discord.
+        </p>
+        <p className="mb-2 ">Be sure to add a ping to <span style={{color: "#eac645"}}><strong>@Congregatio Mirabilis</strong></span> and press <strong>📢 Publish</strong> after posting, so all members and servers get notified!</p>
+    </>
+    const twitterFooterInstructions = <p className="my-2">Paste this text to Twitter and Bluesky.</p>
+    
     return <section>
         <h1 className="display-5">Announcements</h1>
         <Form>
@@ -31,13 +42,14 @@ const EventAnnouncements = () => {
             <Tab eventKey="discord" title="Discord">
                 <EventPasteCard 
                 message={discordMessage} 
-                destinationText="s4-vrchat-events"
-                destinationLink="https://discord.com/channels/1004489038159413248/1004489042890588165"/>
+                footerInstructions={discordFooterInstructions}
+                />
             </Tab>
             <Tab eventKey="twitter" title="Social Media">
                 <EventPasteCard 
                 message={twitterMessage}
-                destinationText="Twitter and Bluesky"/>
+                footerInstructions={twitterFooterInstructions}
+                />
             </Tab>
         </Tabs>
     </section>

--- a/webapp/src/features/event/EventAnnouncements.tsx
+++ b/webapp/src/features/event/EventAnnouncements.tsx
@@ -15,12 +15,13 @@ const EventAnnouncements = () => {
         <Form>
             <Form.Group>
                 <Form.Label>
-                    Event Name
+                    Discord Announcement Message
                 </Form.Label>
                 <Form.Control
                     placeholder="Event Message Goes Here"
                     type="text"
                     as="textarea"
+                    rows={8}
                     value={eventScratchpad.message}
                     onChange={(event) => { proposeEventChange({ ...eventScratchpad, message: event.target.value }); }}
                 />
@@ -28,10 +29,15 @@ const EventAnnouncements = () => {
         </Form>
         <Tabs className="mt-4">
             <Tab eventKey="discord" title="Discord">
-                <EventPasteCard event={eventScratchpad} message={discordMessage}></EventPasteCard>
+                <EventPasteCard 
+                message={discordMessage} 
+                destinationText="s4-vrchat-events"
+                destinationLink="https://discord.com/channels/1004489038159413248/1004489042890588165"/>
             </Tab>
-            <Tab eventKey="twitter" title="Twitter">
-                <EventPasteCard event={eventScratchpad} message={twitterMessage}></EventPasteCard>
+            <Tab eventKey="twitter" title="Social Media">
+                <EventPasteCard 
+                message={twitterMessage}
+                destinationText="Twitter and Bluesky"/>
             </Tab>
         </Tabs>
     </section>

--- a/webapp/src/features/event/EventPasteCard.tsx
+++ b/webapp/src/features/event/EventPasteCard.tsx
@@ -1,18 +1,35 @@
 import { Button, Card, CardBody, CardFooter, Form } from "react-bootstrap";
-import { Event } from "../../util/types";
 
 type Props = {
-    event: Event,
-    message : string
+    message : string,
+    destinationText?: string,
+    destinationLink?: string
 };
 
-const EventPasteCard = ({ event, message }: Props) => {
+const EventPasteCard = ({message, destinationText, destinationLink}: Props) => {
     return <Card>
         <CardBody>
             <Form.Control as="textarea" value={message} rows={16} readOnly className="has-fixed-size" />
         </CardBody>
         <CardFooter className="d-grid gap-2">
-            <Button color={"primary"} onClick={() => { navigator.clipboard.writeText(message); }}>Copy Text</Button>
+            {
+            destinationText ? 
+                (
+                    <p className="mb-0 ">
+                        {destinationLink ? 
+                            <>Copy this to: <a target="_blank" 
+                                                rel="noopener noreferrer" 
+                                                href={destinationLink}>
+                                                    {destinationText}
+                                            </a>.
+                            </>
+                            : <>Copy this to {destinationText}.</>
+                        }
+                    </p>
+                )
+                : ""
+            }
+        <Button color={"primary"} onClick={() => { navigator.clipboard.writeText(message); }}>Copy Text</Button>
         </CardFooter>
     </Card>;
 };

--- a/webapp/src/features/event/EventPasteCard.tsx
+++ b/webapp/src/features/event/EventPasteCard.tsx
@@ -2,33 +2,16 @@ import { Button, Card, CardBody, CardFooter, Form } from "react-bootstrap";
 
 type Props = {
     message : string,
-    destinationText?: string,
-    destinationLink?: string
+    footerInstructions? : React.ReactNode
 };
 
-const EventPasteCard = ({message, destinationText, destinationLink}: Props) => {
+const EventPasteCard = ({message, footerInstructions /* destinationText, destinationLink*/}: Props) => {
     return <Card>
         <CardBody>
             <Form.Control as="textarea" value={message} rows={16} readOnly className="has-fixed-size" />
         </CardBody>
         <CardFooter className="d-grid gap-2">
-            {
-            destinationText ? 
-                (
-                    <p className="mb-0 ">
-                        {destinationLink ? 
-                            <>Copy this to: <a target="_blank" 
-                                                rel="noopener noreferrer" 
-                                                href={destinationLink}>
-                                                    {destinationText}
-                                            </a>.
-                            </>
-                            : <>Copy this to {destinationText}.</>
-                        }
-                    </p>
-                )
-                : ""
-            }
+        { footerInstructions ? footerInstructions : "" }
         <Button color={"primary"} onClick={() => { navigator.clipboard.writeText(message); }}>Copy Text</Button>
         </CardFooter>
     </Card>;

--- a/webapp/src/features/home/Home.tsx
+++ b/webapp/src/features/home/Home.tsx
@@ -4,19 +4,24 @@ import "./Home.css";
 
 const helpfulLinks = [
     {
-        title: "Event Management Guidelines",
-        text: "How S4 is run",
+        title: "Hosting Guide",
+        text: "This is the best place to start if you have any questions on how to host!",
+        url: "https://docs.google.com/document/d/1H1166WjDwJjUBRMHFnx76tX15OLzm-rb-iykcRmpzXc/edit?usp=sharing",
+    },    
+    {
+        title: "S4 Drive Folder",
+        text: "All the spreadsheets and documents relevant to hosting can be found here.",
         url: "https://drive.google.com/drive/u/1/folders/1LSc92ZMwD4B68Ocx0dwKJSE2Eek21SET",
     },
     {
-        title: "Streaming Assets",
-        text: "Images and logos that are used in our streams",
-        url: "https://www.dropbox.com/scl/fo/9cmhbf92l6qgr124vhzap/h?dl=0&e=1",
+        title: "Performer Interest Sheet (Q2)",
+        text: "This is where the performers actually sign up.",
+        url: "https://docs.google.com/spreadsheets/d/1xzejwFYiaFkS7atfWf9YJe7nmZqF_UxwZBjkigoL4DI/edit?usp=sharing",
     },
     {
-        title: "Interest Sheets",
-        text: "These are our actual signups",
-        url: "https://docs.google.com/spreadsheets/u/0/d/1A3eHAnL_-YbwLIezClQ13_R63jdX--ugv5XuOgGfRT0/htmlview",
+        title: "Streaming Assets",
+        text: "Images and logos that are used in our streams, including DJ logos.",
+        url: "https://drive.google.com/drive/u/1/folders/1tuZddCNBcFpVFjyk3XKB6M1d64mAnjX8",
     },
     {
         title: "Whiteboard Endpoint",


### PR DESCRIPTION
* Homepage helpful links have been updated to include some relevant links and descriptions.
* Discord channel link is in there now
* Didn't link to anything for bsky or twitter posting, but added a little note there.
* Removed unused 'event' field in EventPasteCard.

I'm almost certain there's a more elegant way to handle the optional link in EventPasteCard than what I've done here