### PR TITLE
Implement event publishing

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -26,6 +26,9 @@ Every Sunday
 Noon - 5pm-ish PST/PDT
 8pm - 1am-ish BST/BDT`;
 
+/**
+ * Experimental endpoint that can convert to arbitrary timezones
+ */
 export const nextEventBoardAnyTz = onRequest(async (request, response) => {
     logger.info(`Request from ${request.ip}`, { structuredData: true });
 
@@ -45,9 +48,11 @@ export const nextEventBoardAnyTz = onRequest(async (request, response) => {
     response.send(result);
 });
 
+/**
+ * Returns text for the in-world board
+ */
 export const nextEventWhiteboard = onRequest(async (request, response) => {
     logger.info(`Request from ${request.ip}`, { structuredData: true });
-
 
     const event = await getNextEvent();
 
@@ -59,10 +64,12 @@ export const nextEventWhiteboard = onRequest(async (request, response) => {
     response.send(result);
 });
 
-
+/**
+ * Returns data for other tools, like our OBS Scene Generator
+ */
 export const nextEvent = onRequest(async (request, response) => {
     logger.info(`Request from ${request.ip}`, { structuredData: true });
-    response.send(JSON.stringify(await getNextEvent()));
+    response.send(JSON.stringify(await getNextEvent(true)));
 });
 
 // Legacy Endpoint

--- a/functions/util/events.ts
+++ b/functions/util/events.ts
@@ -2,11 +2,20 @@
 import { Timestamp, getFirestore } from "firebase-admin/firestore";
 import { docToEventRaw } from "../../webapp/src/store/converters";
 
-export const getNextEvent = async () => {
-    const docRef = await getFirestore()
+/**
+ * Fetches the next event.
+ * @param {boolean} includeNonPublished If true, the published field will be ignored.  Defaults to `false`
+ * @return {event}
+ */
+export const getNextEvent = async (includeNonPublished = false) => {
+    let docRef = await getFirestore()
         .collection("events")
         .where("end_datetime", ">", Timestamp.now())
         .orderBy("start_datetime", "asc");
+
+    if (!includeNonPublished) {
+        docRef = docRef.where("published", "==", true);
+    }
 
     const snapshot = await docRef.get();
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -13,6 +13,7 @@
                 "react": "^18.2.0",
                 "react-datepicker": "^4.8.0",
                 "react-dom": "^18.2.0",
+                "react-hot-toast": "^2.4.1",
                 "react-router": "^6.22.3",
                 "react-router-bootstrap": "^0.26.3",
                 "react-router-dom": "^6.22.3",
@@ -5441,7 +5442,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/data-urls": {
@@ -7147,6 +7147,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/goober": {
+            "version": "2.1.14",
+            "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+            "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+            "peerDependencies": {
+                "csstype": "^3.0.10"
             }
         },
         "node_modules/google-auth-library": {
@@ -11720,6 +11728,21 @@
             "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
             "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
             "license": "MIT"
+        },
+        "node_modules/react-hot-toast": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+            "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+            "dependencies": {
+                "goober": "^2.1.10"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": ">=16",
+                "react-dom": ">=16"
+            }
         },
         "node_modules/react-is": {
             "version": "18.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -18,6 +18,7 @@
         "react": "^18.2.0",
         "react-datepicker": "^4.8.0",
         "react-dom": "^18.2.0",
+        "react-hot-toast": "^2.4.1",
         "react-router": "^6.22.3",
         "react-router-bootstrap": "^0.26.3",
         "react-router-dom": "^6.22.3",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -21,6 +21,7 @@ import DjDetails from './features/dj/DjDetails';
 import DjList from './features/dj/DjList';
 import EventDetails from './features/event/basic/EventDetails';
 import EventVerifyDJs from './features/event/lineup/EventVerifyDJs';
+import { Toaster } from 'react-hot-toast';
 
 function App() {
   // 
@@ -113,7 +114,10 @@ function App() {
     }
   ]);
 
-  return <RouterProvider router={router} />;
+  return <>
+    <RouterProvider router={router} />
+    <Toaster />
+  </>;
 }
 
 export default App;

--- a/webapp/src/components/currentOrNextEvent/CurrentOrNextEvent.tsx
+++ b/webapp/src/components/currentOrNextEvent/CurrentOrNextEvent.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { Event } from "../../util/types";
 import { getCurrentEvent, getNextEvent } from "../../store/events";
-import { Alert, AlertHeading, Badge, Button, Card, Col, Container, ListGroup, ListGroupItem, Row, Spinner } from "react-bootstrap";
+import { Alert, AlertHeading, Button, Card, Col, Container, ListGroup, ListGroupItem, Row, Spinner } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { LinkContainer } from "react-router-bootstrap";
-import { EventVisibilityBadge } from "../../features/event/EventVisibilityBadge";
+import { EventPublishedStatusBadge } from "../../features/event/EventPublishedStatusBadge";
 
 export const CurrentOrNextEvent = () => {
 
@@ -65,7 +65,7 @@ export const CurrentOrNextEvent = () => {
                         <Card.Text>
                             <Row className="justify-content-md-center">
                                 <Col xs={12} sm={6}>
-                                    <EventVisibilityBadge event={event} />
+                                    <EventPublishedStatusBadge event={event} />
                                     <dl className="mx-2 mt-2">
                                         <dt>Date</dt>
                                         <dd>{event.start_datetime.toDateString()}</dd>

--- a/webapp/src/components/currentOrNextEvent/CurrentOrNextEvent.tsx
+++ b/webapp/src/components/currentOrNextEvent/CurrentOrNextEvent.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { Event } from "../../util/types";
 import { getCurrentEvent, getNextEvent } from "../../store/events";
-import { Alert, AlertHeading, Button, Card, Col, Container, ListGroup, ListGroupItem, Row, Spinner } from "react-bootstrap";
+import { Alert, AlertHeading, Badge, Button, Card, Col, Container, ListGroup, ListGroupItem, Row, Spinner } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { LinkContainer } from "react-router-bootstrap";
+import { EventVisibilityBadge } from "../../features/event/EventVisibilityBadge";
 
 export const CurrentOrNextEvent = () => {
 
@@ -58,16 +59,20 @@ export const CurrentOrNextEvent = () => {
                     <Card.Header>{isCurrentEvent ? "Current Event" : "Next Event"}</Card.Header>
                     <Card.Body>
     
-                        <Card.Title>{event.name}</Card.Title>
+                        <Card.Title>
+                            {event.name}
+                        </Card.Title>
                         <Card.Text>
                             <Row className="justify-content-md-center">
-                                <Col className="d-flex align-items-center" xs={12} sm={6}>
-                                    <dl className="mx-2">
+                                <Col xs={12} sm={6}>
+                                    <EventVisibilityBadge event={event} />
+                                    <dl className="mx-2 mt-2">
                                         <dt>Date</dt>
                                         <dd>{event.start_datetime.toDateString()}</dd>
                                         <dt>Host</dt>
                                         <dd>{event.host}</dd>
                                     </dl>
+                                    <div className="flex-grow-1"></div>
                                 </Col>
                                 <Col xs={12} sm={6}>
                                     <ListGroup>

--- a/webapp/src/features/event/EventPublishedStatusBadge.tsx
+++ b/webapp/src/features/event/EventPublishedStatusBadge.tsx
@@ -19,7 +19,7 @@ const renderPublishedStatusTooltip = (event: Event) => event.published
         </Popover.Body>
     </Popover>;
 
-export const EventVisibilityBadge = ({ event }: Props) =>
+export const EventPublishedStatusBadge = ({ event }: Props) =>
     <OverlayTrigger overlay={renderPublishedStatusTooltip(event)} placement="right">
         <Badge pill bg={ event.published ? "success" : "secondary" } className="mx-2">{ event.published ? "Published" : "Unpublished" } </Badge>
     </OverlayTrigger>

--- a/webapp/src/features/event/EventRoot.tsx
+++ b/webapp/src/features/event/EventRoot.tsx
@@ -74,13 +74,6 @@ const EventRoot = () => {
                 bg="warning"
               >
                 <Toast.Header closeButton={false}>
-                  {/* <img
-                    src="holder.js/20x20?text=%20"
-                    className="rounded me-2"
-                    alt=""
-                  /> */}
-                  {/* <strong className="me-auto">Bootstrap</strong>
-                  <small>11 mins ago</small> */}
                   UwU
                 </Toast.Header>
                 <Toast.Body>

--- a/webapp/src/features/event/EventRoot.tsx
+++ b/webapp/src/features/event/EventRoot.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Alert, Breadcrumb, Button, Container, Nav, Stack, } from 'react-bootstrap';
+import { Alert, Breadcrumb, Button, Container, Nav, Stack, Toast } from 'react-bootstrap';
 import { calcSlotTimes, default_event, saveEvent } from "../../store/events";
 import { docToEvent } from "../../store/converters";
 import { onSnapshot, doc } from "firebase/firestore";
@@ -9,6 +9,7 @@ import FloatingActionBar from "../../components/FloatingActionBar";
 import { Outlet, useLocation, useParams } from "react-router";
 import { Link } from "react-router-dom";
 import { EventPublishedStatusBadge } from "./EventPublishedStatusBadge";
+import toast from "react-hot-toast";
 
 
 const EventRoot = () => {
@@ -41,7 +42,7 @@ const EventRoot = () => {
     useEffect(() => {
         if (!event) return;
         if (hasChanges) {
-            alert("Changes were made outside of this window.");
+            toast("Changes were made outside of this window.");
         } else {
             setEventScratchpad(event);
         }
@@ -68,7 +69,26 @@ const EventRoot = () => {
 
     const publishEvent = async () => {
         if(hasChanges) {
-            alert("Please save changes before publishing this event.\nUwU");
+            toast.custom( <Toast
+                className="d-inline-block m-1"
+                bg="warning"
+              >
+                <Toast.Header closeButton={false}>
+                  {/* <img
+                    src="holder.js/20x20?text=%20"
+                    className="rounded me-2"
+                    alt=""
+                  /> */}
+                  {/* <strong className="me-auto">Bootstrap</strong>
+                  <small>11 mins ago</small> */}
+                  UwU
+                </Toast.Header>
+                <Toast.Body>
+                    Please save changes before publishing this event.
+                </Toast.Body>
+              </Toast>
+            );
+
             return;
         }
 

--- a/webapp/src/features/event/EventRoot.tsx
+++ b/webapp/src/features/event/EventRoot.tsx
@@ -8,7 +8,7 @@ import { db } from "../../util/firebase";
 import FloatingActionBar from "../../components/FloatingActionBar";
 import { Outlet, useLocation, useParams } from "react-router";
 import { Link } from "react-router-dom";
-import { EventVisibilityBadge } from "./EventVisibilityBadge";
+import { EventPublishedStatusBadge } from "./EventPublishedStatusBadge";
 
 
 const EventRoot = () => {
@@ -89,7 +89,7 @@ const EventRoot = () => {
         </h2>
 
         <Stack direction="horizontal" gap={3}>
-                <EventVisibilityBadge event={event} />
+                <EventPublishedStatusBadge event={event} />
                 <div className="ms-auto" />
                 { !event.published  && <Button size="lg" onClick={publishEvent}>Publish Event</Button> }
         </Stack>

--- a/webapp/src/features/event/EventRoot.tsx
+++ b/webapp/src/features/event/EventRoot.tsx
@@ -8,6 +8,7 @@ import { db } from "../../util/firebase";
 import FloatingActionBar from "../../components/FloatingActionBar";
 import { Outlet, useLocation, useParams } from "react-router";
 import { Link } from "react-router-dom";
+import { EventVisibilityBadge } from "./EventVisibilityBadge";
 
 
 const EventRoot = () => {
@@ -65,13 +66,33 @@ const EventRoot = () => {
         setEventScratchpad(event);
     }
 
+    const publishEvent = async () => {
+        if(hasChanges) {
+            alert("Please save changes before publishing this event.\nUwU");
+            return;
+        }
+
+        const newEvent = { ...event, published: true };
+
+        await saveEvent(newEvent);
+        setEventScratchpad(newEvent);
+    }
+
     return <>
         <Breadcrumb className="px-2">
             <Breadcrumb.Item><Link to="/events">Events</Link></Breadcrumb.Item>
             <Breadcrumb.Item><Link to={`/events/${event.id}`}>{event.id}</Link></Breadcrumb.Item>
         </Breadcrumb>
 
-        <h1 className="display-5">Event: {event.name}, {event.start_datetime.toLocaleDateString()}</h1>
+        <h2 className="fw-normal">
+            {event.name} ({event.start_datetime.toLocaleDateString()})<br />
+        </h2>
+
+        <Stack direction="horizontal" gap={3}>
+                <EventVisibilityBadge event={event} />
+                <div className="ms-auto" />
+                { !event.published  && <Button size="lg" onClick={publishEvent}>Publish Event</Button> }
+        </Stack>
 
         <Nav defaultActiveKey="/events/setup" variant="tabs"  as="ul" activeKey={location.pathname}>
             <Nav.Item as="li">

--- a/webapp/src/features/event/EventVisibilityBadge.tsx
+++ b/webapp/src/features/event/EventVisibilityBadge.tsx
@@ -1,0 +1,25 @@
+import { Badge, OverlayTrigger, Popover } from "react-bootstrap";
+import { Event } from "../../util/types";
+
+type Props = {
+    event: Event
+}
+
+const renderPublishedStatusTooltip = (event: Event) => event.published 
+    ? <Popover>
+        <Popover.Header as="h3">Published Event</Popover.Header>
+        <Popover.Body>
+            This event's lineup is visible.
+        </Popover.Body>
+    </Popover>
+    : <Popover>
+        <Popover.Header as="h3">Unpublished Event</Popover.Header>
+        <Popover.Body>
+            This event's lineup will not be displayed until it is published.
+        </Popover.Body>
+    </Popover>;
+
+export const EventVisibilityBadge = ({ event }: Props) =>
+    <OverlayTrigger overlay={renderPublishedStatusTooltip(event)} placement="right">
+        <Badge pill bg={ event.published ? "success" : "secondary" } className="mx-2">{ event.published ? "Published" : "Unpublished" } </Badge>
+    </OverlayTrigger>

--- a/webapp/src/features/event/basic/EventBasicDetailsForm.tsx
+++ b/webapp/src/features/event/basic/EventBasicDetailsForm.tsx
@@ -47,6 +47,16 @@ const EventBasicDetailsForm = ({ event: eventScratchpad, onEventChange: proposeE
                 onChange={(formEvent) => { proposeEventChange({ ...eventScratchpad, host: formEvent.target.value }); }}
             />
         </Form.Group>
+        <Form.Group className="mt-2">
+            <Form.Label>
+                Published
+            </Form.Label>
+            <Form.Check // prettier-ignore
+                type="switch"
+                checked={eventScratchpad.published}
+                onChange={(formEvent) => { proposeEventChange({ ...eventScratchpad, published: formEvent.target.checked }); }}
+            />
+        </Form.Group>
     </Form>
     </>
 

--- a/webapp/src/store/converters.ts
+++ b/webapp/src/store/converters.ts
@@ -37,6 +37,7 @@ export const docToEventRaw = (data: any) => {
           ...data,
           start_datetime: data.start_datetime.toDate(),
           end_datetime: data.end_datetime?.toDate(),
+          published: data.published ?? false,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           slots: data.slots.map((slot: any) => ({ ...slot, start_time: slot.start_time.toDate() }) as Slot),
       } as Event;

--- a/webapp/src/store/events.tsx
+++ b/webapp/src/store/events.tsx
@@ -9,6 +9,7 @@ export const default_event: Event = {
   name: "Sunday Service",
   start_datetime: nextSundayServiceDefaultDateTime(),
   end_datetime: nextSundayServiceDefaultDateTime(),
+  published: false,
   host: "",
   message: "Come by to chill and wiggle to some Sunday Service tunes!",
   slots: [],
@@ -63,8 +64,14 @@ const setDjPlays = (event: Event) => {
   } as Event
 }
 
+/**
+ * Fetches the next event (whether or not it was published)
+ * 
+ * @returns 
+ */
 export const getNextEvent = async () => {
   const q = query(collection(db, "events"), where("end_datetime", ">", Timestamp.now()), orderBy("start_datetime", "asc"));
+  
   const querySnapshot = await getDocs(q);
 
   const events: Event[] = querySnapshot.docs

--- a/webapp/src/util/types.ts
+++ b/webapp/src/util/types.ts
@@ -40,6 +40,7 @@ export type SlotDuration = (0.5 | 1 | 1.5 | 2 | 2.5 | 3 | 3.5 | 4);
 export type Event = {
     id?: string;
     name: string;
+    published: boolean,
     message: string;
     start_datetime: Date;
     end_datetime?: Date;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9506b2a6-6455-46a7-b792-51fea2555def)
![image](https://github.com/user-attachments/assets/306a3896-b1b6-43fb-a3b8-f14c96abb4e3)
![image](https://github.com/user-attachments/assets/5b80bfa0-b47b-4335-aac4-436c0912eedb)
![image](https://github.com/user-attachments/assets/9e5e71b7-3c21-4bbd-b0b1-b142c053e712)
![image](https://github.com/user-attachments/assets/b8157ccf-3e7b-45d6-8995-2c98daef43db)

This is what I had in mind for event publishing.

* There are two separate endpoints now for both getting the lineup text, and getting the lineup for the ObsConfigGenerator.  The latter will get the next event, even if it's not published.  The lineup text will only get the next published event.
* I think this should be a very visible part of the process instead of nested in one of our tabs.  I added a badge to the top of the event root, and if the event is not published, I added a button to publish it.
  * The user is prompted to save changes if there are any unsaved changes and they try to publish
* In case we need to "unpublish" an event, there is a toggle on the event basic setup form.  This behaves like all the other form inputs.