### PR TITLE
Show slot names on the past event list.

### DIFF
--- a/webapp/src/features/event/EventList.tsx
+++ b/webapp/src/features/event/EventList.tsx
@@ -62,7 +62,7 @@ const EventList = ({ past = false}: Props) => {
                         <th>Date</th>
                         <th>Name</th>
                         <th>Host</th>
-                        <th>Number of Slots</th>
+                        <th>Slots</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -70,7 +70,7 @@ const EventList = ({ past = false}: Props) => {
                         <td><Link to={`/events/${event.id}`}>{event.start_datetime.toLocaleDateString()}</Link></td>
                         <td>{event.name}</td>
                         <td>{event.host}</td>
-                        <td>{event.slots.length}</td>
+                        <td>{event.slots.map(slot => slot.dj_name).join(", ")}</td>
                     </tr>)}
                 </tbody>
             </Table>


### PR DESCRIPTION
Had a request from strawbs to be able to see who all played per event in the past few weeks.  This is a quick adjustment we can make to make that possible for now.