### PR TITLE
Change discordid validator to min 17 chars (remove max)

### DIFF
--- a/webapp/src/features/dj/DjForm.tsx
+++ b/webapp/src/features/dj/DjForm.tsx
@@ -27,7 +27,7 @@ const DjForm = ({dj, setDj, busy}: Props) => {
                 value={dj.discord_id}
                 type="input"
                 pattern= "[0-9]{17,}"
-                title="A Discord ID is a 17 or 18 digit user identification number (UID)."
+                title="A Discord ID is a user identification number (UID) at least 17 digits long."
                 onChange={(e) => setDj({...dj, "discord_id": e.target.value})} />
         </Form.Group>
         <Form.Group className="mt-3">

--- a/webapp/src/features/dj/DjForm.tsx
+++ b/webapp/src/features/dj/DjForm.tsx
@@ -26,7 +26,7 @@ const DjForm = ({dj, setDj, busy}: Props) => {
                 name="discord_id"
                 value={dj.discord_id}
                 type="input"
-                pattern= "[0-9]{17,18}"
+                pattern= "[0-9]{17,}"
                 title="A Discord ID is a 17 or 18 digit user identification number (UID)."
                 onChange={(e) => setDj({...dj, "discord_id": e.target.value})} />
         </Form.Group>


### PR DESCRIPTION
Since Luna found the issue that we cant update DJs with discord ids having 19 chars, I went ahead and removed the max quantifier. I found no record of discord having any IDs less than 17 chars long, and 19 chars is likely to last decades, but removing the max quantifier is just as safe since we would catch bad IDs pretty quickly anyway and don't truly rely on them for any data integrity.